### PR TITLE
Adding extra on runs endpoint

### DIFF
--- a/temba_client/v1/__init__.py
+++ b/temba_client/v1/__init__.py
@@ -112,6 +112,7 @@ class TembaClient(BasePagingClient):
         :param str flow: flow UUID
         :param list contacts: list of contact objects or UUIDs
         :param bool restart_participants: whether or not to restart participants already in the flow
+        :param dict extra: extras variables added to the flow and accessed from @extra
         :return: list of new runs
         """
         params = self._build_params(flow_uuid=flow, contacts=contacts, restart_participants=restart_participants,

--- a/temba_client/v1/__init__.py
+++ b/temba_client/v1/__init__.py
@@ -105,7 +105,7 @@ class TembaClient(BasePagingClient):
         params = self._build_params(name=name)
         return Label.deserialize(self._post('labels', params))
 
-    def create_runs(self, flow, contacts, restart_participants):
+    def create_runs(self, flow, contacts, restart_participants, extra=None):
         """
         Creates new flow runs for the given contacts
 
@@ -114,7 +114,8 @@ class TembaClient(BasePagingClient):
         :param bool restart_participants: whether or not to restart participants already in the flow
         :return: list of new runs
         """
-        params = self._build_params(flow_uuid=flow, contacts=contacts, restart_participants=restart_participants)
+        params = self._build_params(flow_uuid=flow, contacts=contacts, restart_participants=restart_participants,
+                                    extra=extra)
         return Run.deserialize_list(self._post('runs', params))
 
     # ==================================================================================================================

--- a/temba_client/v1/tests.py
+++ b/temba_client/v1/tests.py
@@ -134,11 +134,12 @@ class TembaClientTest(TembaTest):
     def test_create_runs(self, mock_request):
         mock_request.return_value = MockResponse(200, self.read_json('runs_created'))
         runs = self.client.create_runs('04a4752b-0f49-480e-ae60-3a3f2bea485c',
-                                       ['bfff9984-38f4-4e59-998d-3663ec3c650d'], True)
+                                       ['bfff9984-38f4-4e59-998d-3663ec3c650d'], True, extra={'variable': 'value'})
 
         expected_body = {"contacts": ['bfff9984-38f4-4e59-998d-3663ec3c650d'],
                          "restart_participants": 1,
-                         "flow_uuid": "04a4752b-0f49-480e-ae60-3a3f2bea485c"}
+                         "flow_uuid": "04a4752b-0f49-480e-ae60-3a3f2bea485c",
+                         "extra": {"variable": "value"}}
         self.assertRequest(mock_request, 'post', 'runs', data=expected_body)
 
         self.assertEqual(len(runs), 2)

--- a/temba_client/v1/tests.py
+++ b/temba_client/v1/tests.py
@@ -134,12 +134,21 @@ class TembaClientTest(TembaTest):
     def test_create_runs(self, mock_request):
         mock_request.return_value = MockResponse(200, self.read_json('runs_created'))
         runs = self.client.create_runs('04a4752b-0f49-480e-ae60-3a3f2bea485c',
+                                       ['bfff9984-38f4-4e59-998d-3663ec3c650d'], True)
+
+        expected_body = {"contacts": ['bfff9984-38f4-4e59-998d-3663ec3c650d'],
+                         "restart_participants": 1,
+                         "flow_uuid": "04a4752b-0f49-480e-ae60-3a3f2bea485c"}
+        self.assertRequest(mock_request, 'post', 'runs', data=expected_body)
+
+        runs = self.client.create_runs('04a4752b-0f49-480e-ae60-3a3f2bea485c',
                                        ['bfff9984-38f4-4e59-998d-3663ec3c650d'], True, extra={'variable': 'value'})
 
         expected_body = {"contacts": ['bfff9984-38f4-4e59-998d-3663ec3c650d'],
                          "restart_participants": 1,
                          "flow_uuid": "04a4752b-0f49-480e-ae60-3a3f2bea485c",
                          "extra": {"variable": "value"}}
+
         self.assertRequest(mock_request, 'post', 'runs', data=expected_body)
 
         self.assertEqual(len(runs), 2)


### PR DESCRIPTION
The Rest API supports extra which adds more variables to the run but the python lib does not. 
