### PR TITLE
V2 updates

### DIFF
--- a/temba_client/clients.py
+++ b/temba_client/clients.py
@@ -53,12 +53,12 @@ class BaseClient(object):
                 'Authorization': 'Token %s' % token,
                 'User-Agent': user_agent_header}
 
-    def _post(self, endpoint, payload):
+    def _post(self, endpoint, params, payload):
         """
         POSTs to the given endpoint which must return a single item or list of items
         """
         url = '%s/%s.json' % (self.root_url, endpoint)
-        return self._request('post', url, body=payload)
+        return self._request('post', url, params=params, body=payload)
 
     def _delete(self, endpoint, params):
         """

--- a/temba_client/v1/__init__.py
+++ b/temba_client/v1/__init__.py
@@ -39,8 +39,8 @@ class TembaClient(BasePagingClient):
         :param list groups: list of group objects or UUIDs
         :return: the new broadcast
         """
-        params = self._build_params(text=text, urns=urns, contacts=contacts, groups=groups)
-        return Broadcast.deserialize(self._post('broadcasts', params))
+        payload = self._build_params(text=text, urns=urns, contacts=contacts, groups=groups)
+        return Broadcast.deserialize(self._post('broadcasts', None, payload))
 
     def create_campaign(self, name, group):
         """
@@ -50,8 +50,8 @@ class TembaClient(BasePagingClient):
         :param str group: contact group object or UUID
         :return: the new campaign
         """
-        params = self._build_params(name=name, group_uuid=group)
-        return Campaign.deserialize(self._post('campaigns', params))
+        payload = self._build_params(name=name, group_uuid=group)
+        return Campaign.deserialize(self._post('campaigns', None, payload))
 
     def create_contact(self, name, urns, fields, groups):
         """
@@ -63,8 +63,8 @@ class TembaClient(BasePagingClient):
         :param list groups: list of group objects or UUIDs
         :return: the new contact
         """
-        params = self._build_params(name=name, urns=urns, fields=fields, group_uuids=groups)
-        return Contact.deserialize(self._post('contacts', params))
+        payload = self._build_params(name=name, urns=urns, fields=fields, group_uuids=groups)
+        return Contact.deserialize(self._post('contacts', None, payload))
 
     def create_event(self, campaign, relative_to, offset, unit, delivery_hour, message=None, flow=None):
         """
@@ -79,9 +79,9 @@ class TembaClient(BasePagingClient):
         :param str flow: flow object or UUID to start (optional)
         :return: the new event
         """
-        params = self._build_params(campaign_uuid=campaign, relative_to=relative_to, offset=offset, unit=unit,
-                                    delivery_hour=delivery_hour, message=message, flow_uuid=flow)
-        return Event.deserialize(self._post('events', params))
+        payload = self._build_params(campaign_uuid=campaign, relative_to=relative_to, offset=offset, unit=unit,
+                                     delivery_hour=delivery_hour, message=message, flow_uuid=flow)
+        return Event.deserialize(self._post('events', None, payload))
 
     def create_field(self, label, value_type, key=None):
         """
@@ -92,8 +92,8 @@ class TembaClient(BasePagingClient):
         :param str key: field key (optional)
         :return: the new field
         """
-        params = self._build_params(label=label, value_type=value_type, key=key)
-        return Field.deserialize(self._post('fields', params))
+        payload = self._build_params(label=label, value_type=value_type, key=key)
+        return Field.deserialize(self._post('fields', None, payload))
 
     def create_label(self, name):
         """
@@ -102,8 +102,8 @@ class TembaClient(BasePagingClient):
         :param str name: label name
         :return: the new message label
         """
-        params = self._build_params(name=name)
-        return Label.deserialize(self._post('labels', params))
+        payload = self._build_params(name=name)
+        return Label.deserialize(self._post('labels', None, payload))
 
     def create_runs(self, flow, contacts, restart_participants, extra=None):
         """
@@ -115,9 +115,9 @@ class TembaClient(BasePagingClient):
         :param dict extra: extras variables added to the flow and accessed from @extra
         :return: list of new runs
         """
-        params = self._build_params(flow_uuid=flow, contacts=contacts, restart_participants=restart_participants,
-                                    extra=extra)
-        return Run.deserialize_list(self._post('runs', params))
+        payload = self._build_params(flow_uuid=flow, contacts=contacts, restart_participants=restart_participants,
+                                     extra=extra)
+        return Run.deserialize_list(self._post('runs', None, payload))
 
     # ==================================================================================================================
     # Delete object operations
@@ -426,7 +426,7 @@ class TembaClient(BasePagingClient):
         :param definition: the flow definition
         :return: the saved definition
         """
-        return FlowDefinition.deserialize(self._post('flow_definition', definition.serialize()))
+        return FlowDefinition.deserialize(self._post('flow_definition', None, definition.serialize()))
 
     # ==================================================================================================================
     # Update object operations
@@ -443,8 +443,8 @@ class TembaClient(BasePagingClient):
         :param list groups: list of group objects or UUIDs
         :return: the updated contact
         """
-        params = self._build_params(uuid=uuid, name=name, urns=urns, fields=fields, group_uuids=groups)
-        return Contact.deserialize(self._post('contacts', params))
+        payload = self._build_params(uuid=uuid, name=name, urns=urns, fields=fields, group_uuids=groups)
+        return Contact.deserialize(self._post('contacts', None, payload))
 
     def update_label(self, uuid, name):
         """
@@ -454,8 +454,8 @@ class TembaClient(BasePagingClient):
         :param str name: label name
         :return: the updated message label
         """
-        params = self._build_params(uuid=uuid, name=name)
-        return Label.deserialize(self._post('labels', params))
+        payload = self._build_params(uuid=uuid, name=name)
+        return Label.deserialize(self._post('labels', None, payload))
 
     # ==================================================================================================================
     # Bulk contact operations
@@ -469,8 +469,8 @@ class TembaClient(BasePagingClient):
         :param str group: the group name
         :param str group_uuid: the group UUID
         """
-        params = self._build_params(contacts=contacts, action='add', group=group, group_uuid=group_uuid)
-        self._post('contact_actions', params)
+        payload = self._build_params(contacts=contacts, action='add', group=group, group_uuid=group_uuid)
+        self._post('contact_actions', None, payload)
 
     def remove_contacts(self, contacts, group=None, group_uuid=None):
         """
@@ -480,8 +480,8 @@ class TembaClient(BasePagingClient):
         :param str group: the group name
         :param str group_uuid: the group UUID
         """
-        params = self._build_params(contacts=contacts, action='remove', group=group, group_uuid=group_uuid)
-        self._post('contact_actions', params)
+        payload = self._build_params(contacts=contacts, action='remove', group=group, group_uuid=group_uuid)
+        self._post('contact_actions', None, payload)
 
     def block_contacts(self, contacts):
         """
@@ -489,7 +489,7 @@ class TembaClient(BasePagingClient):
 
         :param list[str] contacts: the contact UUIDs
         """
-        self._post('contact_actions', self._build_params(contacts=contacts, action='block'))
+        self._post('contact_actions', None, self._build_params(contacts=contacts, action='block'))
 
     def unblock_contacts(self, contacts):
         """
@@ -497,7 +497,7 @@ class TembaClient(BasePagingClient):
 
         :param list[str] contacts: the contact UUIDs
         """
-        self._post('contact_actions', self._build_params(contacts=contacts, action='unblock'))
+        self._post('contact_actions', None, self._build_params(contacts=contacts, action='unblock'))
 
     def archive_contacts(self, contacts):
         """
@@ -505,7 +505,7 @@ class TembaClient(BasePagingClient):
 
         :param list[str] contacts: the contact UUIDs
         """
-        self._post('contact_actions', self._build_params(contacts=contacts, action='archive'))
+        self._post('contact_actions', None, self._build_params(contacts=contacts, action='archive'))
 
     def expire_contacts(self, contacts):
         """
@@ -513,7 +513,7 @@ class TembaClient(BasePagingClient):
 
         :param list[str] contacts: the contact UUIDs
         """
-        self._post('contact_actions', self._build_params(contacts=contacts, action='expire'))
+        self._post('contact_actions', None, self._build_params(contacts=contacts, action='expire'))
 
     def delete_contacts(self, contacts):
         """
@@ -521,7 +521,7 @@ class TembaClient(BasePagingClient):
 
         :param list[str] contacts: the contact UUIDs
         """
-        self._post('contact_actions', self._build_params(contacts=contacts, action='delete'))
+        self._post('contact_actions', None, self._build_params(contacts=contacts, action='delete'))
 
     # ==================================================================================================================
     # Bulk message operations
@@ -536,8 +536,8 @@ class TembaClient(BasePagingClient):
         :param str label: the label name
         :param str label_uuid: the label UUID
         """
-        params = self._build_params(messages=messages, action='label', label=label, label_uuid=label_uuid)
-        self._post('message_actions', params)
+        payload = self._build_params(messages=messages, action='label', label=label, label_uuid=label_uuid)
+        self._post('message_actions', None, payload)
 
     def unlabel_messages(self, messages, label=None, label_uuid=None):
         """
@@ -547,8 +547,8 @@ class TembaClient(BasePagingClient):
         :param str label: the label name
         :param str label_uuid: the label UUID
         """
-        params = self._build_params(messages=messages, action='unlabel', label=label, label_uuid=label_uuid)
-        self._post('message_actions', params)
+        payload = self._build_params(messages=messages, action='unlabel', label=label, label_uuid=label_uuid)
+        self._post('message_actions', None, payload)
 
     def archive_messages(self, messages):
         """
@@ -556,7 +556,7 @@ class TembaClient(BasePagingClient):
 
         :param list[int] messages: the message ids
         """
-        self._post('message_actions', self._build_params(messages=messages, action='archive'))
+        self._post('message_actions', None, self._build_params(messages=messages, action='archive'))
 
     def unarchive_messages(self, messages):
         """
@@ -564,7 +564,7 @@ class TembaClient(BasePagingClient):
 
         :param list[int] messages: the message ids
         """
-        self._post('message_actions', self._build_params(messages=messages, action='unarchive'))
+        self._post('message_actions', None, self._build_params(messages=messages, action='unarchive'))
 
     def delete_messages(self, messages):
         """
@@ -572,4 +572,4 @@ class TembaClient(BasePagingClient):
 
         :param list[int] messages: the message ids
         """
-        self._post('message_actions', self._build_params(messages=messages, action='delete'))
+        self._post('message_actions', None, self._build_params(messages=messages, action='delete'))

--- a/temba_client/v2/__init__.py
+++ b/temba_client/v2/__init__.py
@@ -246,8 +246,8 @@ class TembaClient(BaseCursorClient):
         :param list groups: list of group objects or UUIDs
         :return: the new broadcast
         """
-        params = self._build_params(text=text, urns=urns, contacts=contacts, groups=groups)
-        return Broadcast.deserialize(self._post('broadcasts', params))
+        payload = self._build_params(text=text, urns=urns, contacts=contacts, groups=groups)
+        return Broadcast.deserialize(self._post('broadcasts', None, payload))
 
     def create_contact(self, name=None, language=None, urns=None, fields=None, groups=None):
         """
@@ -260,8 +260,8 @@ class TembaClient(BaseCursorClient):
         :param list groups: list of group objects or UUIDs
         :return: the new contact
         """
-        params = self._build_params(name=name, language=language, urns=urns, fields=fields, groups=groups)
-        return Contact.deserialize(self._post('contacts', params))
+        payload = self._build_params(name=name, language=language, urns=urns, fields=fields, groups=groups)
+        return Contact.deserialize(self._post('contacts', None, payload))
 
     def create_flow_start(self, flow, urns=None, contacts=None, groups=None, restart_participants=None, extra=None):
         """
@@ -275,9 +275,9 @@ class TembaClient(BaseCursorClient):
         :param * extra: a dictionary of extra parameters to pass to the flow
         :return: the new label
         """
-        params = self._build_params(flow=flow, urns=urns, contacts=contacts, groups=groups,
-                                    restart_participants=restart_participants, extra=extra)
-        return FlowStart.deserialize(self._post('flow_starts', params))
+        payload = self._build_params(flow=flow, urns=urns, contacts=contacts, groups=groups,
+                                     restart_participants=restart_participants, extra=extra)
+        return FlowStart.deserialize(self._post('flow_starts', None, payload))
 
     def create_group(self, name):
         """
@@ -286,7 +286,7 @@ class TembaClient(BaseCursorClient):
         :param str name: group name
         :return: the new group
         """
-        return Group.deserialize(self._post('groups', self._build_params(name=name)))
+        return Group.deserialize(self._post('groups', None, self._build_params(name=name)))
 
     def create_label(self, name):
         """
@@ -295,7 +295,7 @@ class TembaClient(BaseCursorClient):
         :param str name: label name
         :return: the new label
         """
-        return Label.deserialize(self._post('labels', self._build_params(name=name)))
+        return Label.deserialize(self._post('labels', None, self._build_params(name=name)))
 
     def create_resthook_subscriber(self, resthook, target_url):
         """
@@ -305,8 +305,8 @@ class TembaClient(BaseCursorClient):
         :param target_url: the target URL
         :return: the new subscriber
         """
-        params = self._build_params(resthook=resthook, target_url=target_url)
-        return ResthookSubscriber.deserialize(self._post('resthook_subscribers', params))
+        payload = self._build_params(resthook=resthook, target_url=target_url)
+        return ResthookSubscriber.deserialize(self._post('resthook_subscribers', None, payload))
 
     # ==================================================================================================================
     # Update object operations
@@ -324,9 +324,9 @@ class TembaClient(BaseCursorClient):
         :param list groups: list of group objects or UUIDs
         :return: the updated contact
         """
-        params = dict(name=name, language=language, urns=urns, fields=fields, groups=groups)
-        params['urn' if ':' in uuid_or_urn else 'uuid'] = uuid_or_urn
-        return Contact.deserialize(self._post('contacts', self._build_params(**params)))
+        params = {'urn' if ':' in uuid_or_urn else 'uuid': uuid_or_urn}
+        payload = self._build_params(name=name, language=language, urns=urns, fields=fields, groups=groups)
+        return Contact.deserialize(self._post('contacts', params, self._build_params(**payload)))
 
     def update_group(self, uuid, name):
         """
@@ -336,7 +336,7 @@ class TembaClient(BaseCursorClient):
         :param str name: group name
         :return: the updated group
         """
-        return Group.deserialize(self._post('groups', self._build_params(uuid=uuid, name=name)))
+        return Group.deserialize(self._post('groups', None, self._build_params(uuid=uuid, name=name)))
 
     def update_label(self, uuid, name):
         """
@@ -346,7 +346,7 @@ class TembaClient(BaseCursorClient):
         :param str name: label name
         :return: the updated label
         """
-        return Label.deserialize(self._post('labels', self._build_params(uuid=uuid, name=name)))
+        return Label.deserialize(self._post('labels', None, self._build_params(uuid=uuid, name=name)))
 
     # ==================================================================================================================
     # Delete object operations

--- a/temba_client/v2/__init__.py
+++ b/temba_client/v2/__init__.py
@@ -5,6 +5,8 @@ This version of the API is still under development and so is subject to change w
 that users continue using the existing API v1.
 """
 
+import six
+
 from .types import Boundary, Broadcast, Campaign, CampaignEvent, Channel, ChannelEvent, Contact, Export, Field
 from .types import FlowStart, Flow, Group, Label, Message, Org, Resthook, ResthookSubscriber, ResthookEvent, Run
 from ..clients import BaseCursorClient
@@ -312,11 +314,11 @@ class TembaClient(BaseCursorClient):
     # Update object operations
     # ==================================================================================================================
 
-    def update_contact(self, uuid_or_urn, name=None, language=None, urns=None, fields=None, groups=None):
+    def update_contact(self, contact, name=None, language=None, urns=None, fields=None, groups=None):
         """
         Updates an existing contact
 
-        :param str uuid_or_urn: contact UUID or URN
+        :param * contact: contact object, UUID or URN
         :param str name: full name
         :param str language: the language code, e.g. "eng"
         :param list[str] urns: list of URN strings
@@ -324,63 +326,65 @@ class TembaClient(BaseCursorClient):
         :param list groups: list of group objects or UUIDs
         :return: the updated contact
         """
-        params = {'urn' if ':' in uuid_or_urn else 'uuid': uuid_or_urn}
+        is_urn = isinstance(contact, six.string_types) and ':' in contact
+        params = self._build_params(**{'urn' if is_urn else 'uuid': contact})
         payload = self._build_params(name=name, language=language, urns=urns, fields=fields, groups=groups)
         return Contact.deserialize(self._post('contacts', params, self._build_params(**payload)))
 
-    def update_group(self, uuid, name):
+    def update_group(self, group, name):
         """
         Updates an existing contact group
 
-        :param str uuid: group UUID
+        :param * group: group object or UUID
         :param str name: group name
         :return: the updated group
         """
-        return Group.deserialize(self._post('groups', {'uuid': uuid}, self._build_params(name=name)))
+        return Group.deserialize(self._post('groups', self._build_params(uuid=group), self._build_params(name=name)))
 
-    def update_label(self, uuid, name):
+    def update_label(self, label, name):
         """
         Updates an existing message label
 
-        :param str uuid: label UUID
+        :param * label: label object or UUID
         :param str name: label name
         :return: the updated label
         """
-        return Label.deserialize(self._post('labels', {'uuid': uuid}, self._build_params(name=name)))
+        return Label.deserialize(self._post('labels', self._build_params(uuid=label), self._build_params(name=name)))
 
     # ==================================================================================================================
     # Delete object operations
     # ==================================================================================================================
 
-    def delete_contact(self, uuid_or_urn):
+    def delete_contact(self, contact):
         """
         Deletes an existing contact
 
-        :param str uuid_or_urn: contact UUID or URN
+        :param * contact: contact object, UUID or URN
         """
-        params = {'urn' if ':' in uuid_or_urn else 'uuid': uuid_or_urn}
-        self._delete('contacts', self._build_params(**params))
+        is_urn = isinstance(contact, six.string_types) and ':' in contact
+        params = self._build_params(**{'urn' if is_urn else 'uuid': contact})
+        self._delete('contacts', params)
 
-    def delete_group(self, uuid):
+    def delete_group(self, group):
         """
         Deletes an existing contact group
 
-        :param str uuid: group UUID
+        :param * group: group object or UUID
         """
-        self._delete('groups', self._build_params(uuid=uuid))
+        self._delete('groups', self._build_params(uuid=group))
 
-    def delete_label(self, uuid):
+    def delete_label(self, label):
         """
         Deletes an existing message label
 
-        :param str uuid: label UUID
+        :param * label: label object or UUID
         """
-        self._delete('labels', self._build_params(uuid=uuid))
+        self._delete('labels', self._build_params(uuid=label))
 
-    def delete_resthook_subscriber(self, id):
+    def delete_resthook_subscriber(self, subscriber):
         """
         Deletes an existing resthook subscriber
 
-        :param id: the resthook subscriber id
+        :param * subscriber: the resthook subscriber or id
         """
-        self._delete('resthook_subscribers', self._build_params(id=id))
+        self._delete('resthook_subscribers', self._build_params(id=subscriber))

--- a/temba_client/v2/__init__.py
+++ b/temba_client/v2/__init__.py
@@ -336,7 +336,7 @@ class TembaClient(BaseCursorClient):
         :param str name: group name
         :return: the updated group
         """
-        return Group.deserialize(self._post('groups', None, self._build_params(uuid=uuid, name=name)))
+        return Group.deserialize(self._post('groups', {'uuid': uuid}, self._build_params(name=name)))
 
     def update_label(self, uuid, name):
         """
@@ -346,7 +346,7 @@ class TembaClient(BaseCursorClient):
         :param str name: label name
         :return: the updated label
         """
-        return Label.deserialize(self._post('labels', None, self._build_params(uuid=uuid, name=name)))
+        return Label.deserialize(self._post('labels', {'uuid': uuid}, self._build_params(name=name)))
 
     # ==================================================================================================================
     # Delete object operations

--- a/temba_client/v2/tests.py
+++ b/temba_client/v2/tests.py
@@ -6,6 +6,7 @@ import pytz
 from mock import patch
 from requests.exceptions import ConnectionError
 from . import TembaClient
+from .types import Contact, Group, Label, ResthookSubscriber
 from ..exceptions import TembaBadRequestError, TembaTokenError, TembaRateExceededError, TembaHttpError
 from ..exceptions import TembaConnectionError
 from ..tests import TembaTest, MockResponse
@@ -735,7 +736,7 @@ class TembaClientTest(TembaTest):
 
         # check update by UUID
         contact = self.client.update_contact(
-            uuid_or_urn="5079cb96-a1d8-4f47-8c87-d8c7bb6ddab9",
+            contact="5079cb96-a1d8-4f47-8c87-d8c7bb6ddab9",
             name="Joe",
             language="eng",
             urns=["tel:+250973635665"],
@@ -755,14 +756,16 @@ class TembaClientTest(TembaTest):
         self.assertEqual(contact.uuid, "5079cb96-a1d8-4f47-8c87-d8c7bb6ddab9")
 
         # check partial update by URN
-        self.client.update_contact(uuid_or_urn="tel:+250973635665", language="fre")
+        self.client.update_contact(contact="tel:+250973635665", language="fre")
 
         self.assertRequest(mock_request, 'post', 'contacts',
                            params={'urn': "tel:+250973635665"}, data={'language': "fre"})
 
     def test_update_group(self, mock_request):
         mock_request.return_value = MockResponse(201, self.read_json('groups', extract_result=0))
-        group = self.client.update_group(uuid="04a4752b-0f49-480e-ae60-3a3f2bea485c", name="Reporters")
+
+        # check update by UUID
+        group = self.client.update_group(group="04a4752b-0f49-480e-ae60-3a3f2bea485c", name="Reporters")
 
         self.assertRequest(mock_request, 'post', 'groups',
                            params={'uuid': "04a4752b-0f49-480e-ae60-3a3f2bea485c"},
@@ -771,7 +774,9 @@ class TembaClientTest(TembaTest):
 
     def test_update_label(self, mock_request):
         mock_request.return_value = MockResponse(201, self.read_json('labels', extract_result=0))
-        label = self.client.update_label(uuid="04a4752b-0f49-480e-ae60-3a3f2bea485c", name="Important")
+
+        # check update by UUID
+        label = self.client.update_label(label="04a4752b-0f49-480e-ae60-3a3f2bea485c", name="Important")
 
         self.assertRequest(mock_request, 'post', 'labels',
                            params={'uuid': "04a4752b-0f49-480e-ae60-3a3f2bea485c"},
@@ -781,33 +786,56 @@ class TembaClientTest(TembaTest):
     def test_delete_contact(self, mock_request):
         mock_request.return_value = MockResponse(204, "")
 
+        # check delete by object
+        self.client.delete_contact(Contact.create(uuid="5079cb96-a1d8-4f47-8c87-d8c7bb6ddab9"))
+
+        self.assertRequest(mock_request, 'delete', 'contacts', params={'uuid': "5079cb96-a1d8-4f47-8c87-d8c7bb6ddab9"})
+
         # check delete by UUID
-        self.client.delete_contact(uuid_or_urn="5079cb96-a1d8-4f47-8c87-d8c7bb6ddab9")
+        self.client.delete_contact("5079cb96-a1d8-4f47-8c87-d8c7bb6ddab9")
 
         self.assertRequest(mock_request, 'delete', 'contacts', params={'uuid': "5079cb96-a1d8-4f47-8c87-d8c7bb6ddab9"})
 
         # check delete by URN
-        self.client.delete_contact(uuid_or_urn="tel:+250973635665")
+        self.client.delete_contact("tel:+250973635665")
 
         self.assertRequest(mock_request, 'delete', 'contacts', params={'urn': "tel:+250973635665"})
 
     def test_delete_group(self, mock_request):
         mock_request.return_value = MockResponse(204, "")
 
-        self.client.delete_group(uuid="04a4752b-0f49-480e-ae60-3a3f2bea485c")
+        # check delete by object
+        self.client.delete_group(Group.create(uuid="04a4752b-0f49-480e-ae60-3a3f2bea485c"))
+
+        self.assertRequest(mock_request, 'delete', 'groups', params={'uuid': "04a4752b-0f49-480e-ae60-3a3f2bea485c"})
+
+        # check delete by UUID
+        self.client.delete_group("04a4752b-0f49-480e-ae60-3a3f2bea485c")
 
         self.assertRequest(mock_request, 'delete', 'groups', params={'uuid': "04a4752b-0f49-480e-ae60-3a3f2bea485c"})
 
     def test_delete_label(self, mock_request):
         mock_request.return_value = MockResponse(204, "")
 
-        self.client.delete_label(uuid="5079cb96-a1d8-4f47-8c87-d8c7bb6ddab9")
+        # check delete by object
+        self.client.delete_label(Label.create(uuid="5079cb96-a1d8-4f47-8c87-d8c7bb6ddab9"))
+
+        self.assertRequest(mock_request, 'delete', 'labels', params={'uuid': "5079cb96-a1d8-4f47-8c87-d8c7bb6ddab9"})
+
+        # check delete by UUID
+        self.client.delete_label("5079cb96-a1d8-4f47-8c87-d8c7bb6ddab9")
 
         self.assertRequest(mock_request, 'delete', 'labels', params={'uuid': "5079cb96-a1d8-4f47-8c87-d8c7bb6ddab9"})
 
     def test_delete_resthook_subscriber(self, mock_request):
         mock_request.return_value = MockResponse(204, "")
 
-        self.client.delete_resthook_subscriber(id=1001)
+        # check delete by object
+        self.client.delete_resthook_subscriber(ResthookSubscriber.create(id=1001))
+
+        self.assertRequest(mock_request, 'delete', 'resthook_subscribers', params={'id': 1001})
+
+        # check delete by id
+        self.client.delete_resthook_subscriber(1001)
 
         self.assertRequest(mock_request, 'delete', 'resthook_subscribers', params={'id': 1001})

--- a/temba_client/v2/tests.py
+++ b/temba_client/v2/tests.py
@@ -743,8 +743,9 @@ class TembaClientTest(TembaTest):
             groups=["d29eca7c-a475-4d8d-98ca-bff968341356"]
         )
 
-        self.assertRequest(mock_request, 'post', 'contacts', data={
-            'uuid': "5079cb96-a1d8-4f47-8c87-d8c7bb6ddab9",
+        self.assertRequest(mock_request, 'post', 'contacts', params={
+            'uuid': "5079cb96-a1d8-4f47-8c87-d8c7bb6ddab9"
+        }, data={
             'name': "Joe",
             'language': "eng",
             'urns': ["tel:+250973635665"],
@@ -756,7 +757,8 @@ class TembaClientTest(TembaTest):
         # check partial update by URN
         self.client.update_contact(uuid_or_urn="tel:+250973635665", language="fre")
 
-        self.assertRequest(mock_request, 'post', 'contacts', data={'urn': "tel:+250973635665", 'language': "fre"})
+        self.assertRequest(mock_request, 'post', 'contacts',
+                           params={'urn': "tel:+250973635665"}, data={'language': "fre"})
 
     def test_update_group(self, mock_request):
         mock_request.return_value = MockResponse(201, self.read_json('groups', extract_result=0))

--- a/temba_client/v2/tests.py
+++ b/temba_client/v2/tests.py
@@ -743,15 +743,15 @@ class TembaClientTest(TembaTest):
             groups=["d29eca7c-a475-4d8d-98ca-bff968341356"]
         )
 
-        self.assertRequest(mock_request, 'post', 'contacts', params={
-            'uuid': "5079cb96-a1d8-4f47-8c87-d8c7bb6ddab9"
-        }, data={
-            'name': "Joe",
-            'language': "eng",
-            'urns': ["tel:+250973635665"],
-            'fields': {"nickname": "Jo", "age": 34},
-            'groups': ["d29eca7c-a475-4d8d-98ca-bff968341356"]
-        })
+        self.assertRequest(mock_request, 'post', 'contacts',
+                           params={'uuid': "5079cb96-a1d8-4f47-8c87-d8c7bb6ddab9"},
+                           data={
+                               'name': "Joe",
+                               'language': "eng",
+                               'urns': ["tel:+250973635665"],
+                               'fields': {"nickname": "Jo", "age": 34},
+                               'groups': ["d29eca7c-a475-4d8d-98ca-bff968341356"]
+                           })
         self.assertEqual(contact.uuid, "5079cb96-a1d8-4f47-8c87-d8c7bb6ddab9")
 
         # check partial update by URN
@@ -764,20 +764,18 @@ class TembaClientTest(TembaTest):
         mock_request.return_value = MockResponse(201, self.read_json('groups', extract_result=0))
         group = self.client.update_group(uuid="04a4752b-0f49-480e-ae60-3a3f2bea485c", name="Reporters")
 
-        self.assertRequest(mock_request, 'post', 'groups', data={
-            'uuid': "04a4752b-0f49-480e-ae60-3a3f2bea485c",
-            'name': "Reporters"
-        })
+        self.assertRequest(mock_request, 'post', 'groups',
+                           params={'uuid': "04a4752b-0f49-480e-ae60-3a3f2bea485c"},
+                           data={'name': "Reporters"})
         self.assertEqual(group.uuid, "04a4752b-0f49-480e-ae60-3a3f2bea485c")
 
     def test_update_label(self, mock_request):
         mock_request.return_value = MockResponse(201, self.read_json('labels', extract_result=0))
         label = self.client.update_label(uuid="04a4752b-0f49-480e-ae60-3a3f2bea485c", name="Important")
 
-        self.assertRequest(mock_request, 'post', 'labels', data={
-            'uuid': "04a4752b-0f49-480e-ae60-3a3f2bea485c",
-            'name': "Important"
-        })
+        self.assertRequest(mock_request, 'post', 'labels',
+                           params={'uuid': "04a4752b-0f49-480e-ae60-3a3f2bea485c"},
+                           data={'name': "Important"})
         self.assertEqual(label.uuid, "04a4752b-0f49-480e-ae60-3a3f2bea485c")
 
     def test_delete_contact(self, mock_request):


### PR DESCRIPTION
- Pass UUID etc as querystring params in POSTs
- Let update/delete methods take object instances, e.g. 

``` python
contact = client.get_contact(uuid="1234-4567-7890")
client.delete_contact(contact)
```
