### PR TITLE
Allow specifying the `verify` parameter for requests

### DIFF
--- a/temba_client/clients.py
+++ b/temba_client/clients.py
@@ -29,7 +29,7 @@ class BaseClient(object):
     """
     __metaclass__ = ABCMeta
 
-    def __init__(self, host, token, api_version, user_agent=None, verify=None):
+    def __init__(self, host, token, api_version, user_agent=None, verify_ssl=None):
         if host.startswith('http'):
             host_url = host
             if host_url.endswith('/'):  # trim a final slash
@@ -41,7 +41,7 @@ class BaseClient(object):
 
         self.headers = self._headers(token, user_agent)
 
-        self.verify = verify
+        self.verify_ssl = verify_ssl
 
     @staticmethod
     def _headers(token, user_agent):
@@ -83,8 +83,7 @@ class BaseClient(object):
             if params:
                 kwargs['params'] = params
 
-            if self.verify is not None:
-                kwargs['verify'] = self.verify
+            kwargs['verify'] = self.verify_ssl
 
             response = request(method, url, **kwargs)
 

--- a/temba_client/clients.py
+++ b/temba_client/clients.py
@@ -29,7 +29,7 @@ class BaseClient(object):
     """
     __metaclass__ = ABCMeta
 
-    def __init__(self, host, token, api_version, user_agent=None):
+    def __init__(self, host, token, api_version, user_agent=None, verify=None):
         if host.startswith('http'):
             host_url = host
             if host_url.endswith('/'):  # trim a final slash
@@ -40,6 +40,8 @@ class BaseClient(object):
         self.root_url = '%s/api/v%d' % (host_url, api_version)
 
         self.headers = self._headers(token, user_agent)
+
+        self.verify = verify
 
     @staticmethod
     def _headers(token, user_agent):
@@ -80,6 +82,9 @@ class BaseClient(object):
                 kwargs['data'] = body
             if params:
                 kwargs['params'] = params
+
+            if self.verify is not None:
+                kwargs['verify'] = self.verify
 
             response = request(method, url, **kwargs)
 

--- a/temba_client/tests.py
+++ b/temba_client/tests.py
@@ -51,7 +51,7 @@ class TembaTest(unittest.TestCase):
                                 headers={'Content-type': 'application/json',
                                          'Authorization': 'Token 1234567890',
                                          'Accept': u'application/json',
-                                         'User-Agent': 'test/0.1 rapidpro-python/%s' % __version__}, **kwargs)
+                                         'User-Agent': 'test/0.1 rapidpro-python/%s' % __version__}, verify=None, **kwargs)
         mock.reset_mock()
 
     def assertRequest(self, mock, method, endpoint, **kwargs):
@@ -226,14 +226,14 @@ class BaseClientTest(TembaTest):
         client = BaseClientTest.Client('http://example.com/', '1234567890', 1)
         self.assertEqual(client.root_url, 'http://example.com/api/v1')
 
-        # verify parameter for requests
+        # verify_ssl parameter for requests
         client = BaseClientTest.Client('example.com', '1234567890', 2)
-        self.assertEqual(client.verify, None)
-        client = BaseClientTest.Client('example.com', '1234567890', 2, verify=False)
-        self.assertFalse(client.verify)
-        client = BaseClientTest.Client('example.com', '1234567890', 2, verify='/path/to/certfile')
-        self.assertTrue(client.verify)
-        self.assertEqual(client.verify, '/path/to/certfile')
+        self.assertEqual(client.verify_ssl, None)
+        client = BaseClientTest.Client('example.com', '1234567890', 2, verify_ssl=False)
+        self.assertFalse(client.verify_ssl)
+        client = BaseClientTest.Client('example.com', '1234567890', 2, verify_ssl='/path/to/certfile')
+        self.assertTrue(client.verify_ssl)
+        self.assertEqual(client.verify_ssl, '/path/to/certfile')
 
 
 # ====================================================================================

--- a/temba_client/tests.py
+++ b/temba_client/tests.py
@@ -51,7 +51,8 @@ class TembaTest(unittest.TestCase):
                                 headers={'Content-type': 'application/json',
                                          'Authorization': 'Token 1234567890',
                                          'Accept': u'application/json',
-                                         'User-Agent': 'test/0.1 rapidpro-python/%s' % __version__}, verify=None, **kwargs)
+                                         'User-Agent': 'test/0.1 rapidpro-python/%s' % __version__},
+                                verify=None, **kwargs)
         mock.reset_mock()
 
     def assertRequest(self, mock, method, endpoint, **kwargs):

--- a/temba_client/tests.py
+++ b/temba_client/tests.py
@@ -226,6 +226,15 @@ class BaseClientTest(TembaTest):
         client = BaseClientTest.Client('http://example.com/', '1234567890', 1)
         self.assertEqual(client.root_url, 'http://example.com/api/v1')
 
+        # verify parameter for requests
+        client = BaseClientTest.Client('example.com', '1234567890', 2)
+        self.assertEqual(client.verify, None)
+        client = BaseClientTest.Client('example.com', '1234567890', 2, verify=False)
+        self.assertFalse(client.verify)
+        client = BaseClientTest.Client('example.com', '1234567890', 2, verify='/path/to/certfile')
+        self.assertTrue(client.verify)
+        self.assertEqual(client.verify, '/path/to/certfile')
+
 
 # ====================================================================================
 # Test utilities

--- a/temba_client/v1/__init__.py
+++ b/temba_client/v1/__init__.py
@@ -13,8 +13,8 @@ class TembaClient(BasePagingClient):
     :param str token: organization API token
     :param str user_agent: string to be included in the User-Agent header
     """
-    def __init__(self, host, token, user_agent=None):
-        super(TembaClient, self).__init__(host, token, 1, user_agent)
+    def __init__(self, host, token, user_agent=None, verify=None):
+        super(TembaClient, self).__init__(host, token, 1, user_agent, verify)
 
     def pager(self, start_page=1):
         """

--- a/temba_client/v1/__init__.py
+++ b/temba_client/v1/__init__.py
@@ -13,8 +13,8 @@ class TembaClient(BasePagingClient):
     :param str token: organization API token
     :param str user_agent: string to be included in the User-Agent header
     """
-    def __init__(self, host, token, user_agent=None, verify=None):
-        super(TembaClient, self).__init__(host, token, 1, user_agent, verify)
+    def __init__(self, host, token, user_agent=None, verify_ssl=None):
+        super(TembaClient, self).__init__(host, token, 1, user_agent, verify_ssl)
 
     def pager(self, start_page=1):
         """

--- a/temba_client/v1/tests.py
+++ b/temba_client/v1/tests.py
@@ -843,3 +843,23 @@ class TembaClientTest(TembaTest):
             self.assertEqual(six.text_type(ex), "xyz")
         else:
             self.fail("Should have thrown exception")
+
+
+@patch('temba_client.clients.request')
+class TembaClientVerifyTest(TembaTest):
+
+    def test_verify_false(self, mock_request):
+        client = TembaClient('example.com', '12345', verify_ssl=False)
+        self.assertFalse(client.verify_ssl)
+
+    def test_verify_true(self, mock_request):
+        client = TembaClient('example.com', '12345', verify_ssl=True)
+        self.assertTrue(client.verify_ssl)
+
+    def test_verify_path(self, mock_request):
+        client = TembaClient('example.com', '12345', verify_ssl='/path/to/cert')
+        self.assertEqual(client.verify_ssl, '/path/to/cert')
+
+    def test_verify_notset(self, mock_request):
+        client = TembaClient('example.com', '12345')
+        self.assertEqual(client.verify_ssl, None)

--- a/temba_client/v2/__init__.py
+++ b/temba_client/v2/__init__.py
@@ -20,8 +20,8 @@ class TembaClient(BaseCursorClient):
     :param str token: organization API token
     :param str user_agent: string to be included in the User-Agent header
     """
-    def __init__(self, host, token, user_agent=None, verify=None):
-        super(TembaClient, self).__init__(host, token, 2, user_agent, verify)
+    def __init__(self, host, token, user_agent=None, verify_ssl=None):
+        super(TembaClient, self).__init__(host, token, 2, user_agent, verify_ssl)
 
     # ==================================================================================================================
     # Fetch object operations

--- a/temba_client/v2/__init__.py
+++ b/temba_client/v2/__init__.py
@@ -20,8 +20,8 @@ class TembaClient(BaseCursorClient):
     :param str token: organization API token
     :param str user_agent: string to be included in the User-Agent header
     """
-    def __init__(self, host, token, user_agent=None):
-        super(TembaClient, self).__init__(host, token, 2, user_agent)
+    def __init__(self, host, token, user_agent=None, verify=None):
+        super(TembaClient, self).__init__(host, token, 2, user_agent, verify)
 
     # ==================================================================================================================
     # Fetch object operations

--- a/temba_client/v2/tests.py
+++ b/temba_client/v2/tests.py
@@ -1044,3 +1044,23 @@ class TembaClientTest(TembaTest):
         self.client.bulk_delete_messages(messages=messages)
         self.assertRequest(mock_request, 'post', 'message_actions',
                            data={'messages': resolved_messages, 'action': 'delete'})
+
+
+@patch('temba_client.clients.request')
+class TembaClientVerifyTest(TembaTest):
+
+    def test_verify_false(self, mock_request):
+        client = TembaClient('example.com', '12345', verify_ssl=False)
+        self.assertFalse(client.verify_ssl)
+
+    def test_verify_true(self, mock_request):
+        client = TembaClient('example.com', '12345', verify_ssl=True)
+        self.assertTrue(client.verify_ssl)
+
+    def test_verify_path(self, mock_request):
+        client = TembaClient('example.com', '12345', verify_ssl='/path/to/cert')
+        self.assertEqual(client.verify_ssl, '/path/to/cert')
+
+    def test_verify_notset(self, mock_request):
+        client = TembaClient('example.com', '12345')
+        self.assertEqual(client.verify_ssl, None)


### PR DESCRIPTION
Hey, more of a question than a PR at this time.
Currently there's no way to bypass SSL verification of requests made by the client.
I have a particular use case where the rapidpro server is using a self-signed certificate on a private network.

I believe it's harmless to offer people the opportunity to set this requests flag (`verify`) which can either be `True` (default), `False` (No SSL verification) or a path to a CA bundle file to which the server certificate would be verified upon.

See [requests' advanced section](http://docs.python-requests.org/en/latest/user/advanced/) for more info.

I haven't added support for the `cert` parameter which is client-side certificate to establish SSL connection with as I have no need for this at the moment and it seems overkill.

Let me know how you feel about adding support for `verify` and how should that `TembaClient` parameter be named.