### PR TITLE
sync latest changes to ChannelEvents

### DIFF
--- a/temba_client/v2/tests.py
+++ b/temba_client/v2/tests.py
@@ -292,8 +292,8 @@ class TembaClientTest(TembaTest):
         self.assertEqual(results[0].contact.name, "Frank McFlow")
         self.assertEqual(results[0].channel.uuid, "9a8b001e-a913-486c-80f4-1356e23f582e")
         self.assertEqual(results[0].channel.name, "Nexmo")
-        self.assertEqual(results[0].time, datetime.datetime(2016, 1, 6, 15, 35, 3, 675716, pytz.utc))
-        self.assertEqual(results[0].duration, 123)
+        self.assertEqual(results[0].extra, {"foo": "bar"})
+        self.assertEqual(results[0].occurred_on, datetime.datetime(2016, 1, 6, 15, 35, 3, 675716, pytz.utc))
         self.assertEqual(results[0].created_on, datetime.datetime(2016, 1, 6, 15, 33, 0, 813162, pytz.utc))
 
         # check with all params

--- a/temba_client/v2/types.py
+++ b/temba_client/v2/types.py
@@ -88,8 +88,8 @@ class ChannelEvent(TembaObject):
     type = SimpleField()
     contact = ObjectField(item_class=ObjectRef)
     channel = ObjectField(item_class=ObjectRef)
-    time = DatetimeField()
-    duration = IntegerField()
+    extra = SimpleField()
+    occurred_on = DatetimeField()
     created_on = DatetimeField()
 
 

--- a/test_files/v2/channel_events.json
+++ b/test_files/v2/channel_events.json
@@ -7,8 +7,8 @@
             "type": "in",
             "contact": {"uuid": "d33e9ad5-5c35-414c-abd4-e7451c69ff1d", "name": "Frank McFlow"},
             "channel": {"uuid": "9a8b001e-a913-486c-80f4-1356e23f582e", "name": "Nexmo"},
-            "time": "2016-01-06T15:35:03.675716Z",
-            "duration": 123,
+            "extra": {"foo": "bar"},
+            "occurred_on": "2016-01-06T15:35:03.675716Z",
             "created_on": "2016-01-06T15:33:00.813162Z"
         },
         {
@@ -16,8 +16,8 @@
             "type": "out",
             "contact": {"uuid": "d33e9ad5-5c35-414c-abd4-e7451c69ff1d", "name": "Frank McFlow"},
             "channel": {"uuid": "9a8b001e-a913-486c-80f4-1356e23f582e", "name": "Nexmo"},
-            "time": "2015-11-10T12:59:11.101787Z",
-            "duration": 123,
+            "extra": {},
+            "occurred_on": "2015-11-10T12:59:11.101787Z",
             "created_on": "2015-11-10T12:59:10.123456Z"
         }
     ]


### PR DESCRIPTION
backports changes from https://github.com/nyaruka/rapidpro/pull/1409 into this api library.

@nicpottier if this looks good it'd be helpful to get a new release on pip since the lib is currently broken when used against https://app.rapidpro.io/