### PR TITLE
make example uuid an actual uuid

### DIFF
--- a/test_files/v2/campaign_events.json
+++ b/test_files/v2/campaign_events.json
@@ -3,7 +3,7 @@
     "previous": null,
     "results": [
         {
-            "uuid": "9e6beda-0ce2-46cd-8810-91157f261cbd",
+            "uuid": "9e6beda-0ce2-46cd-8810-91157f261cbde",
             "campaign": {"uuid": "9ccae91f-b3f8-4c18-ad92-e795a2332c11", "name": "Reminders"},
             "relative_to": {"key": "edd", "label": "EDD"},
             "offset": 14,

--- a/test_files/v2/campaign_events.json
+++ b/test_files/v2/campaign_events.json
@@ -3,7 +3,7 @@
     "previous": null,
     "results": [
         {
-            "uuid": "9e6beda-0ce2-46cd-8810-91157f261cbde",
+            "uuid": "9e6bedae-0ce2-46cd-8810-91157f261cbd",
             "campaign": {"uuid": "9ccae91f-b3f8-4c18-ad92-e795a2332c11", "name": "Reminders"},
             "relative_to": {"key": "edd", "label": "EDD"},
             "offset": 14,


### PR DESCRIPTION
the example uuid in this file is malformed (missing a character) which if you actually try to convert it to a python uuid raises an exception "ValueError: badly formed hexadecimal UUID string"