### PR TITLE
Fix TembaSerializationException stringification

### DIFF
--- a/temba_client/exceptions.py
+++ b/temba_client/exceptions.py
@@ -56,7 +56,8 @@ class TembaHttpError(TembaException):
 
 
 class TembaSerializationException(TembaException):
-    pass
+    def __init__(self, message):
+        self.message = message
 
 
 class TembaMultipleResultsError(TembaException):

--- a/temba_client/tests.py
+++ b/temba_client/tests.py
@@ -106,6 +106,12 @@ class TestType(TembaObject):
     meh = ObjectDictField(item_class=TestSubType)
 
 
+class TembaSerializationExceptionTest(TembaTest):
+    def test_str_works(self):
+        err = TembaSerializationException("boop")
+        self.assertEqual(str(err), "boop")
+
+
 class FieldsTest(TembaTest):
     def test_boolean(self):
         field = BooleanField()


### PR DESCRIPTION
This should fix #65!

One funky thing is that running `nosetests --with-coverage --cover-erase --cover-package=temba_client --cover-html` didn't seem to actually find any tests, nor did running just `nosetests` on its own.  I ended up manually running test suites via e.g. `nosetests temba_client/tests.py` and that worked.
