### PR TITLE
Add `paths` parameter to `get_runs`

### DIFF
--- a/temba_client/base.py
+++ b/temba_client/base.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 MAX_RETRIES = 5
 
 
-class BaseClient(object):
+class BaseClient:
     """
     Abstract base client
     """

--- a/temba_client/v2/__init__.py
+++ b/temba_client/v2/__init__.py
@@ -272,7 +272,9 @@ class TembaClient(BaseCursorClient):
         params = self._build_params(id=id, resthook=resthook)
         return self._get_query("resthook_subscribers", params, ResthookSubscriber)
 
-    def get_runs(self, id=None, flow=None, contact=None, responded=None, before=None, after=None, reverse=None, paths=None):
+    def get_runs(
+        self, id=None, flow=None, contact=None, responded=None, before=None, after=None, reverse=None, paths=None
+    ):
         """
         Gets all matching flow runs
 
@@ -287,7 +289,14 @@ class TembaClient(BaseCursorClient):
         :return: flow run query
         """
         params = self._build_params(
-            id=id, flow=flow, contact=contact, responded=responded, reverse=reverse, before=before, after=after, paths=paths
+            id=id,
+            flow=flow,
+            contact=contact,
+            responded=responded,
+            reverse=reverse,
+            before=before,
+            after=after,
+            paths=paths,
         )
         return self._get_query("runs", params, Run)
 

--- a/temba_client/v2/__init__.py
+++ b/temba_client/v2/__init__.py
@@ -272,7 +272,7 @@ class TembaClient(BaseCursorClient):
         params = self._build_params(id=id, resthook=resthook)
         return self._get_query("resthook_subscribers", params, ResthookSubscriber)
 
-    def get_runs(self, id=None, flow=None, contact=None, responded=None, before=None, after=None, reverse=None):
+    def get_runs(self, id=None, flow=None, contact=None, responded=None, before=None, after=None, reverse=None, paths=None):
         """
         Gets all matching flow runs
 
@@ -280,13 +280,14 @@ class TembaClient(BaseCursorClient):
         :param flow: flow object or UUID
         :param contact: contact object or UUID
         :param responded: whether to limit results to runs with responses
-        :param reverse: whether to return results ordered in reverse (oldest first).
         :param datetime before: modified before
         :param datetime after: modified after
+        :param reverse: whether to return results ordered in reverse (oldest first).
+        :param paths: whether to include path data
         :return: flow run query
         """
         params = self._build_params(
-            id=id, flow=flow, contact=contact, responded=responded, reverse=reverse, before=before, after=after
+            id=id, flow=flow, contact=contact, responded=responded, reverse=reverse, before=before, after=after, paths=paths
         )
         return self._get_query("runs", params, Run)
 

--- a/temba_client/v2/tests.py
+++ b/temba_client/v2/tests.py
@@ -760,6 +760,7 @@ class TembaClientTest(TembaTest):
             after=datetime.datetime(2014, 12, 12, 22, 34, 36, 978123, pytz.utc),
             before=datetime.datetime(2014, 12, 12, 22, 56, 58, 917123, pytz.utc),
             reverse=False,
+            paths=True,
         ).all()
 
         self.assertRequest(
@@ -771,9 +772,10 @@ class TembaClientTest(TembaTest):
                 "flow": "ffce0fbb-4fe1-4052-b26a-91beb2ebae9a",
                 "contact": "d33e9ad5-5c35-414c-abd4-e7451c69ff1d",
                 "responded": True,
-                "reverse": False,
                 "after": "2014-12-12T22:34:36.978123Z",
                 "before": "2014-12-12T22:56:58.917123Z",
+                "reverse": False,
+                "paths": True,
             },
         )
 


### PR DESCRIPTION
1. Start having U-Report etc send `paths=true` with requests for runs
2. Make RapidPro API default to not returning path data unless requested with `paths=true`
3. Figure out how to make U-Report work without path data
4. Stop returning path data from the API altogether, and stop writing it with runs.