### PR TITLE
Replace deprecated pkg_resources

### DIFF
--- a/temba_client/__init__.py
+++ b/temba_client/__init__.py
@@ -1,4 +1,4 @@
-import pkg_resources
+from importlib import metadata
 
 CLIENT_NAME = "rapidpro-python"
-CLIENT_VERSION = pkg_resources.get_distribution("rapidpro-python").version
+CLIENT_VERSION = metadata.version("rapidpro-python")


### PR DESCRIPTION
I started to hit issues importing this package in python 3.12. This updates the code to use the the newer `importlib` method. 

https://docs.python.org/3/library/importlib.metadata.html