### PR TITLE
Replace isort with ruff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,6 @@ jobs:
       - name: Run ruff
         run: uv run ruff check temba_client
 
-      - name: Run isort
-        run: uv run isort temba_client
-
       - name: Run tests
         run: uv run nose2 -C --coverage temba_client --coverage-report term --coverage-report xml
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ Repository = "http://github.com/rapidpro/rapidpro-python"
 dev = [
     "coverage>=5.3,<6",
     "ruff>=0.15.7,<0.16",
-    "isort>=5.10.1,<6",
     "nose2>=0.12.0,<0.13",
 ]
 
@@ -44,13 +43,9 @@ line-length = 120
 fix = true
 
 [tool.ruff.lint]
-select = ["E", "F", "W"]
+select = ["E", "F", "W", "I"]
 ignore = ["E501", "F405"]
 
-[tool.isort]
-multi_line_output = 3
-force_grid_wrap = 0
-line_length = 120
-include_trailing_comma = true
-combine_as_imports = true
-sections = ["FUTURE", "STDLIB", "THIRDPARTY", "FIRSTPARTY", "LOCALFOLDER"]
+[tool.ruff.lint.isort]
+combine-as-imports = true
+known-first-party = ["temba_client"]

--- a/uv.lock
+++ b/uv.lock
@@ -71,15 +71,6 @@ wheels = [
 ]
 
 [[package]]
-name = "isort"
-version = "5.13.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/87/f9/c1eb8635a24e87ade2efce21e3ce8cd6b8630bb685ddc9cdaca1349b2eb5/isort-5.13.2.tar.gz", hash = "sha256:48fdfcb9face5d58a4f6dde2e72a1fb8dcaf8ab26f95ab49fab84c2ddefb0109", size = 175303, upload-time = "2023-12-13T20:37:26.124Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d1/b3/8def84f539e7d2289a02f0524b944b15d7c75dab7628bedf1c4f0992029c/isort-5.13.2-py3-none-any.whl", hash = "sha256:8ca5e72a8d85860d5a3fa69b8745237f2939afe12dbf656afbcb47fe72d947a6", size = 92310, upload-time = "2023-12-13T20:37:23.244Z" },
-]
-
-[[package]]
 name = "nose2"
 version = "0.12.0"
 source = { registry = "https://pypi.org/simple" }
@@ -100,7 +91,6 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "coverage" },
-    { name = "isort" },
     { name = "nose2" },
     { name = "ruff" },
 ]
@@ -114,7 +104,6 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "coverage", specifier = ">=5.3,<6" },
-    { name = "isort", specifier = ">=5.10.1,<6" },
     { name = "nose2", specifier = ">=0.12.0,<0.13" },
     { name = "ruff", specifier = ">=0.15.7,<0.16" },
 ]


### PR DESCRIPTION
## Summary
- Remove isort dependency and use ruff's built-in import sorting (`I` rule) instead
- Add `[tool.ruff.lint.isort]` config with `combine-as-imports` and `known-first-party`
- Remove separate isort CI step (now covered by `ruff check`)